### PR TITLE
Standardizing RPC error codes

### DIFF
--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -4,20 +4,20 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"regexp"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/light/provider"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/types"
 )
 
 // This is very brittle, see: https://github.com/tendermint/tendermint/issues/4740
 var (
-	regexpMissingHeight = regexp.MustCompile(`height \d+ (must be less than or equal to|is not available)`)
-	maxRetryAttempts    = 10
+	maxRetryAttempts = 10
 )
 
 // http provider uses an RPC client to obtain the necessary information.
@@ -108,8 +108,7 @@ func (p *http) validatorSet(ctx context.Context, height *int64) (*types.Validato
 		for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 			res, err := p.client.Validators(ctx, height, &page, &maxPerPage)
 			if err != nil {
-				// TODO: standardize errors on the RPC side
-				if regexpMissingHeight.MatchString(err.Error()) {
+				if err = errors.Cause(err); err == ctypes.ErrHeightNotAvailable || err == ctypes.ErrInvalidHeight {
 					return nil, provider.ErrLightBlockNotFound
 				}
 				// if we have exceeded retry attempts then return no response error
@@ -143,8 +142,7 @@ func (p *http) signedHeader(ctx context.Context, height *int64) (*types.SignedHe
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		commit, err := p.client.Commit(ctx, height)
 		if err != nil {
-			// TODO: standardize errors on the RPC side
-			if regexpMissingHeight.MatchString(err.Error()) {
+			if err = errors.Cause(err); err == ctypes.ErrHeightNotAvailable || err == ctypes.ErrInvalidHeight {
 				return nil, provider.ErrLightBlockNotFound
 			}
 			// we wait and try again with exponential backoff

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -3,11 +3,11 @@ package rpc
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
@@ -562,7 +562,7 @@ const (
 
 func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	if perPage < 1 {
-		panic(fmt.Sprintf("zero or negative perPage: %d", perPage))
+		panic(errors.Wrapf(ctypes.ErrZeroOrNegativePerPage, "%d", perPage))
 	}
 
 	if pagePtr == nil { // no page parameter
@@ -575,7 +575,7 @@ func validatePage(pagePtr *int, perPage, totalCount int) (int, error) {
 	}
 	page := *pagePtr
 	if page <= 0 || page > pages {
-		return 1, fmt.Errorf("page should be within [1, %d] range, given %d", pages, page)
+		return 1, errors.Wrapf(ctypes.ErrPageOutOfRange, "expected range: [1, %d], given %d", pages, page)
 	}
 
 	return page, nil

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -2,6 +2,7 @@ package coretypes
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -10,6 +11,15 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
+)
+
+// List of standardized errors used across RPC
+var (
+	ErrZeroOrNegativePerPage = errors.New("zero or negative perPage")
+	ErrPageOutOfRange        = errors.New("page should be within range")
+	ErrNegativeHeight        = errors.New("height must be greater than zero")
+	ErrInvalidHeight         = errors.New("height must be less than or equal to the current blockchain height")
+	ErrHeightNotAvailable    = errors.New("height is not available")
 )
 
 // List of blocks


### PR DESCRIPTION
## Description

The changes in this PR standardize the error codes returned by the RPC core. Currently, the RPC clients use regex to determine the error. 

Furthermore, changes have been made to return appropriate HTTP status codes and RPC responses based on the error encountered. In the existing implementation, all errors are returned as internal server errors, even for client errors such as bad requests.

## Issue Reference
https://github.com/tendermint/tendermint/issues/4740